### PR TITLE
Update according to change in cerbot v0.9.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Defaults
 - `renew_days: 10`
 - `rsa_key_size: 2048`
 - `ssl_days_remaining: "{{ renew_days }}"`
-- `standalone_supported_challenges: "tls-sni-01"`
+- `preferred_challenges: "tls-sni-01"`
 - `webroot_path: ""`
 
 To Do

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,5 +7,5 @@ letsencrypt_server: https://acme-staging.api.letsencrypt.org/directory
 renew_days: 10
 rsa_key_size: 2048
 ssl_days_remaining: "{{ renew_days }}"
-standalone_supported_challenges: "tls-sni-01"
+preferred_challenges: "tls-sni-01"
 webroot_path: ""

--- a/tasks/generate-crt.yml
+++ b/tasks/generate-crt.yml
@@ -33,7 +33,7 @@
         - name: Set force_renew_command
           set_fact:
             force_renew_command: "--force-renewal"
-          when: ( "{{ force_renewal }}" is defined )
+          when: ( force_renewal is defined )
 
         - name: Set force renewal fact
           set_fact:
@@ -42,7 +42,7 @@
         - name: Set installer_command fact
           set_fact:
             installer_command: "--installer"
-          when: ( "{{ server_type }}" is defined)
+          when: ( server_type is defined)
 
         - name: Set installer_server_type
           set_fact:
@@ -54,15 +54,15 @@
 
         - name: Generate certificate (Standalone) no install
           command: "letsencrypt {{ force_renew }} {{ installer_server_type }} --agree-tos certonly -d {{ subdomain }}.{{ domain }}"
-          when: cert_exists.stat.exists and ( "{{ cert_expiring_soon }}" is defined )
+          when: cert_exists.stat.exists and ( cert_expiring_soon is defined )
 
         - name: Generate certificate (Standalone) no install
           command: "letsencrypt {{ force_renew }} {{ installer_server_type }} --agree-tos certonly -d {{ subdomain }}.{{ domain }}"
-          when: cert_exists.stat.exists and ( "{{ force_renewal }}" is defined )
+          when: cert_exists.stat.exists and ( force_renewal is defined )
 
       when: ( "{{ authenticator }}" == "standalone" )
-  when: ( "{{ revoke }}" is not defined )
+  when: ( revoke is undefined )
 
 - name: Revoke certificate
   command: "letsencrypt revoke --cert-path {{ certificate_path }}/{{ subdomain }}.{{ domain }}/cert.pem"
-  when: cert_exists.stat.exists and ( "{{ revoke }}" is defined )
+  when: cert_exists.stat.exists and ( revoke is defined )

--- a/templates/cli.ini.j2
+++ b/templates/cli.ini.j2
@@ -21,7 +21,7 @@ text = True
 {% if authenticator == "standalone" %}
 # Uncomment to use the standalone authenticator on port 443
 authenticator = standalone
-standalone-supported-challenges = {{ standalone_supported_challenges }}
+preferred-challenges = {{ preferred_challenges }}
 {% elif authenticator == "webroot" and webroot_path %}
 # Uncomment to use the webroot authenticator. Replace webroot-path with the
 # path to the public_html / webroot folder being served by your web server.


### PR DESCRIPTION
The --standalone-supported-challenges option has been deprecated since certbot version 0.9.0.